### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Dockerfile compliance
-        run: docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+        run: docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM docker.io/centos:centos7
 
 # Install all required packages
 # hadolint ignore=DL3033, DL3013, DL3003

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE=reanahub/reana-env-aliphysics
+IMAGE=docker.io/reanahub/reana-env-aliphysics
 
 all:
 	@echo "Usage: make <action> where action is build, test, or push."

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ If you would like to try it locally, you can run:
 
 .. code-block:: console
 
-   $ docker run -i -t --rm -v $HOME/foo:/foo reana-env-aliphysics:vAN-20170521-1 /bin/bash
+   $ docker run -i -t --rm -v $HOME/foo:/foo docker.io/reanahub/reana-env-aliphysics:vAN-20170521-1 /bin/bash
 
 which will drop you to a shell with the appropriate AliPhysics environment
 already set. Everything you write in ``/foo`` inside the container will be


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.